### PR TITLE
better compatibility with ESMTP RFC

### DIFF
--- a/src/ufront/mail/Email.hx
+++ b/src/ufront/mail/Email.hx
@@ -150,10 +150,12 @@ class Email {
 	If no such header exists, it will return `null`.
 	**/
 	public function getHeader( name ):Null<String> {
-		if ( headers.exists(name) )
-			return headers.get( name )[0];
-		else
+		if ( headers.exists(name) ) {
+			var h = headers.get( name ); 
+			return h[0];
+		}else{
 			return null;
+		}
 	}
 
 	/**

--- a/src/ufront/mailer/SmtpMailer.hx
+++ b/src/ufront/mailer/SmtpMailer.hx
@@ -141,22 +141,25 @@ class SmtpMailer implements UFMailer {
 			throw ConnectionError(host,port);
 		}
 
+		var esmtp = false;
 		var supportLoginAuth = false;
 
 		// get server init line
 		var ret = StringTools.trim(cnx.input.readLine());
-		var esmtp = ret.indexOf("ESMTP") >= 0;
-
 
 		while (StringTools.startsWith(ret, "220-")) {
 			ret = StringTools.trim(cnx.input.readLine());
 		}
+		
+		//see https://en.wikipedia.org/wiki/Extended_SMTP
+		cnx.write( "EHLO " + Host.localhost() + "\r\n");
+		ret = StringTools.trim(cnx.input.readLine());
+		if ( ret.substr(0, 3) == "250" ){
+			esmtp = true;
+		}
+		
 
 		if ( esmtp ) { //if server support extensions
-			//EHLO
-			cnx.write( "EHLO " + Host.localhost() + "\r\n");
-			ret = "";
-
 			do {
 				ret = StringTools.trim(cnx.input.readLine());
 				if( ret.substr(0,3) != "250" ){


### PR DESCRIPTION
I noticed some incompatibilities while using ufront-mail with OVH.com SMTP servers  ( OVH is one of the biggest web hosting companies in France ).   The old code was looking for the "ESMTP" string in the first reply, as the RFC asks to send "EHLO" and check the return code to know if ESMTP features are available.

For instance, OVH servers don't print this "ESMTP" string, while supporting ESMTP features : 

```
Trying 213.186.33.20...
Connected to ssl0.ovh.net.
Escape character is '^]'.
220 ssl0.ovh.net player789
EHLO
501 Syntax: EHLO hostname
EHLO ssl0.ovh.net
250-player789.ha.ovh.net
250-SIZE 104850000
250-STARTTLS
250-AUTH PLAIN LOGIN
250-AUTH=PLAIN LOGIN
250-ENHANCEDSTATUSCODES
250 8BITMIME
```

https://en.wikipedia.org/wiki/Extended_SMTP
